### PR TITLE
Replace UwU logo

### DIFF
--- a/README.uwu.md
+++ b/README.uwu.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="https://static.wikia.nocookie.net/blue-archive/images/4/48/Seia_Halo.png" width="128" />
+<img src="https://static.wikia.nocookie.net/blue-archive/images/1/10/Seia_Icon.png" width="128" />
 
 # Seia
 

--- a/examples/blue-archive-students/CHANGELOG.md
+++ b/examples/blue-archive-students/CHANGELOG.md
@@ -1,5 +1,12 @@
 # blue-archive-students
 
+## 1.0.2
+
+### Patch Changes
+
+- Updated dependencies
+  - seia.js@0.1.2
+
 ## 1.0.1
 
 ### Patch Changes

--- a/examples/blue-archive-students/package.json
+++ b/examples/blue-archive-students/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blue-archive-students",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"type": "module",
 	"scripts": {
 		"build": "seia build",

--- a/packages/seia/CHANGELOG.md
+++ b/packages/seia/CHANGELOG.md
@@ -1,5 +1,11 @@
 # seia.js
 
+## 0.1.2
+
+### Patch Changes
+
+- - #6 Thanks @nemorize! - Fixed some typos in codebase and documentations
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/seia/README.md
+++ b/packages/seia/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="https://static.wikia.nocookie.net/blue-archive/images/1/10/Seia_Icon.png" width="128" />
+<img src="https://static.wikia.nocookie.net/blue-archive/images/4/48/Seia_Halo.png" width="128" />
 
 # Seia
 
@@ -154,8 +154,7 @@ Your support is invaluable for the ongoing maintenance and improvement of Seia. 
 
 ## :raising_hand: Where's the name from?
 
-[Yurizono
-Seia(<ruby>百合<rt>ゆり</rt></ruby><ruby>園<rt>ぞの</rt></ruby>セイア)](https://bluearchive.fandom.com/wiki/Yurizono_Seia), member of the [Tea Party](https://bluearchive.fandom.com/wiki/Tea_Party) at [Trinity](https://bluearchive.fandom.com/wiki/Trinity_General_School) in the [Blue Archive](https://bluearchive.nexon.com/home).
+[Yurizono Seia(<ruby>百合<rt>ゆり</rt></ruby><ruby>園<rt>ぞの</rt></ruby>セイア)](https://bluearchive.fandom.com/wiki/Yurizono_Seia), member of the [Tea Party](https://bluearchive.fandom.com/wiki/Tea_Party) at [Trinity](https://bluearchive.fandom.com/wiki/Trinity_General_School) in the [Blue Archive](https://bluearchive.nexon.com/home).
 
 ## :grey_question: What does the default port number `5314` mean?
 

--- a/packages/seia/package.json
+++ b/packages/seia/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "seia.js",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"type": "module",
 	"description": "Lightweight SSR framework for React Server Components",
 	"keywords": [


### PR DESCRIPTION
## Problem

- This project started as a toy project, especially a meme for Blue Archive.
- Directly using anime pictures at README may make the project appear less serious.
- The character IP belongs to Nexon, which could lead to potential legal issues.

## Proposed Solutions
- Temporarily replace Seia's illustration with her halo, which seems less 'weeby' to those unfamiliar with Blue Archive.
- Maybe, we can create a new logo that resembles the halo closely enough to maintain thematic consistency while avoiding legal complications.

## Future works

- Provide a more 'sane' example than the Blue Archive students sample.