### PR TITLE
fix(create-seia-app): replace `import.meta.dirname` with compatible alternative

### DIFF
--- a/packages/create-seia-app/src/index.ts
+++ b/packages/create-seia-app/src/index.ts
@@ -1,4 +1,6 @@
 import { cp, rm, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import { Args, Command, Flags } from '@oclif/core'
 import { Liquid } from 'liquidjs'
@@ -89,7 +91,11 @@ export default class Index extends Command {
 
 		const template = ts ? 'typescript' : 'javascript'
 
-		await cp(`${import.meta.dirname}/../templates/${template}`, name, {
+		const currentFilename = fileURLToPath(import.meta.url)
+
+		const currentDirname = dirname(currentFilename)
+
+		await cp(`${currentDirname}/../templates/${template}`, name, {
 			recursive: true,
 		})
 


### PR DESCRIPTION
Since import.meta.dirname is an experimental feature with a stability index of 1.2, change it to stable code that does the same thing.