### PR TITLE
fix: force serve command to render JSX in production mode

### DIFF
--- a/.changeset/hot-tomatoes-divide.md
+++ b/.changeset/hot-tomatoes-divide.md
@@ -1,0 +1,5 @@
+---
+'seia.js': patch
+---
+
+Fix JSX runtime issue on yarn berry

--- a/packages/seia/src/commands/start.ts
+++ b/packages/seia/src/commands/start.ts
@@ -1,3 +1,5 @@
+import process from 'node:process'
+
 import { Args, Flags } from '@oclif/core'
 
 import { SeiaCommand } from '../command.js'
@@ -28,6 +30,9 @@ export default class Start extends SeiaCommand {
 		const {
 			flags: { port },
 		} = await this.parse(Start)
+
+		// HACK: Force server to run in production mode
+		process.env.NODE_ENV = 'production'
 
 		await serve(
 			extendResolvedSeiaConfig(this.resolvedConfig, {


### PR DESCRIPTION
## Problem

It seems that yarn berry can't resolve path import tied with `react-server` condition. (uncertain)

## Solution

We can resolve this by forcing `seia serve` command to run the RSC worker in production mode, resulting in JSX runtime not using `JSXDev` function.